### PR TITLE
Fix plugin after changing private key logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const do_upload = function (workspace, vargs) {
       port: vargs.port,
       username: vargs.username,
       password: vargs.password,
-      privateKey: workspace.keys.private
+      privateKey: workspace.keys && workspace.keys['private']
     }).then(function (greetings) {
       console.log('Connection successful. ' + (greetings || ''));
      


### PR DESCRIPTION
The change I made to support Drone generated key in the SFTP library broke the plugin.

- Made sure to pass nothing if keys absent (For testing)
- Use array notation as 'private' is a reserved word