### PR TITLE
Add options to authenticate using a private key

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -5,14 +5,17 @@ You can override the default configuration with the following parameters:
 * `port` - Server port, default to 22
 * `username` - Server username, default to blank
 * `password` - Password for password-based authentication
+* `key` - Private key for public-key-based authentication
+* `key_path` - Private key path for public-key-based authentication
+* `passphrase` - Passphrase of your key for public-key-based authentication (optional)
 * `destination_path` - Target path on the server, default to '/'
 * `files` - List of files to upload
 
 All file paths must be relative to current project sources
 
-## Example
+## Examples
 
-The following is a sample configuration in your .drone.yml file:
+Sample configuration using a password in your .drone.yml file:
 
 ```yaml
 publish:
@@ -21,6 +24,21 @@ publish:
     port: 2222
     username: user
     password: pa$$word
-    files: 
+    files:
+      - *.nupkg
+```
+
+Sample configuration using a private key saved as a secret in your .drone.yml file:
+
+```yaml
+publish:
+  sftp:
+    host: sftp.company.com
+    port: 2222
+    username: user
+    key:
+      from_secret: sftp_private_key
+    passphrase: my_passphrase
+    files:
       - *.nupkg
 ```


### PR DESCRIPTION
This PR adds three new options to authenticate to an SFTP server using a private key:

- `PLUGIN_KEY`: source content of private key
- `PLUGIN_KEY_PATH`: path of the private key
- `PLUGIN_PASSPHRASE`: passphrase used to parse the private key (if needed)

Resolves #8